### PR TITLE
Fixed the link

### DIFF
--- a/docs/methods/zom/simulated-annealing.md
+++ b/docs/methods/zom/simulated-annealing.md
@@ -43,7 +43,7 @@ As it mentioned in [Simulated annealing: a proof of convergence](https://ieeexpl
 
 ## Illustration
 
-A gif from [Wikipedia](https://en.wikipedia.org/wiki/Markdown):
+A gif from [Wikipedia](https://en.wikipedia.org/wiki/Simulated_annealing):
 
 ![](../sa_wiki.gif)
 


### PR DESCRIPTION
It used to lead to the Markdown article on wiki instead of https://en.wikipedia.org/wiki/Simulated_annealing for some reason