### PR TITLE
Consider instead of let us have

### DIFF
--- a/docs/theory/Rates_of_convergence.md
+++ b/docs/theory/Rates_of_convergence.md
@@ -4,35 +4,35 @@ title: Rates of convergence
 ---
 
 ## Speed of convergence
-In order to compare perfomance of algorithms we need to define a terminology for different types of convergence.
+In order to compare the performance of algorithms we need to define a terminology for different types of convergence.
 Let $r_k = \{\|x_k - x^*\|_2\}$ be a sequence in $\mathbb{R}^n$ that converges to zero.
 
 ### Linear convergence
 
-We can define the *linear* convergence in a two different forms:
+We can define *linear* convergence in two different forms:
 
 $$
 \| x_{k+1} - x^* \|_2 \leq Cq^k \quad\text{or} \quad \| x_{k+1} - x^* \|_2 \leq q\| x_k - x^* \|_2,
 $$
 
-for all sufficiently large $k$. Here $q \in (0, 1)$ and $0 < C < \infty$. This means that the distance to the solution $x^*$ decreases at each iteration by at least a constant factor bounded away from $1$. Note, that sometimes this type of convergence is also called *exponential* or *geometric*. We call the $q$ the convergence rate.
+for all sufficiently large $k$. Here $q \in (0, 1)$ and $0 < C < \infty$. This means that the distance to the solution $x^*$ decreases at each iteration by at least a constant factor bounded away from $1$. Note that this type of convergence is also sometimes called *exponential* or *geometric*. We call the $q$ the convergence rate.
 
 :::{.callout-question}
-Suppose, you have two sequences with linear convergence rates $q_1 = 0.1$ and $q_2 = 0.7$, which one is faster?
+Suppose you have two sequences with linear convergence rates $q_1 = 0.1$ and $q_2 = 0.7$, which one is faster?
 :::
 
 :::{.callout-example}
-Let us have the following sequence:
+Consider the following sequence:
 
 $$
 r_k = \dfrac{1}{3^k}
 $$
 
-One can immediately conclude, that we have a linear convergence with parameters $q = \dfrac{1}{3}$ and $C = 0$.
+We can immediately conclude that the sequence converges linearly with parameters $q = \dfrac{1}{3}$ and $C = 0$.
 :::
 
 :::{.callout-question}
-Let us have the following sequence:
+Consider the following sequence:
 
 $$
 r_k = \dfrac{4}{3^k}
@@ -43,7 +43,7 @@ Will this sequence be convergent? What is the convergence rate?
 
 ### Sublinear convergence
 
-If the sequence $r_k$ converges to zero, but does not have linear convergence, the convergence is said to be sublinear. Sometimes we can considet the following class of sublinear convergence:
+If the sequence $r_k$ converges to zero but does not have linear convergence, the convergence is said to be sublinear. Sometimes we can consider the following class of sublinear convergence:
 
 $$
 \| x_{k+1} - x^* \|_2 \leq C k^{q},
@@ -59,7 +59,7 @@ $$
 \| x_{k+1} - x^* \|_2 \leq Cq^{k^2} \qquad \text{or} \qquad \| x_{k+1} - x^* \|_2 \leq C_k\| x_k - x^* \|_2,
 $$
 
-where $q \in (0, 1)$ or $0 < C_k < \infty$, $C_k \to 0$. Note, that superlinear convergence is also linear convergence (one can even say, that it is linear convergence with $q=0$).
+where $q \in (0, 1)$ or $0 < C_k < \infty$, $C_k \to 0$. Note that superlinear convergence is also linear convergence (one can even say it is linear convergence with $q=0$).
 
 ### Quadratic convergence
 
@@ -105,7 +105,7 @@ $$
 * In all other cases (i.e., when $\lim\limits_{k \to \infty} \inf_k \dfrac{r_{k+1}}{r_k} \lt  1 \leq  \lim\limits_{k \to \infty} \sup_k \dfrac{r_{k+1}}{r_k}$) we cannot claim anything concrete about the convergence rate $\{r_k\}_{k=m}^\infty$.
 
 :::{.callout-example}
-Let us have the following sequence:
+Consider the following sequence:
 
 $$
 r_k = \dfrac{1}{k}
@@ -115,7 +115,7 @@ Determine the convergence
 :::
 
 :::{.callout-example}
-Let us have the following sequence:
+Consider the following sequence:
 
 $$
 r_k = \dfrac{1}{k^2}
@@ -125,7 +125,7 @@ Determine the convergence
 :::
 
 :::{.callout-example}
-Let us have the following sequence:
+Consider the following sequence:
 
 $$
 r_k = \dfrac{1}{k^q}, q > 1
@@ -136,8 +136,8 @@ Determine the convergence
 
 :::{.callout-example}
 
-## Try to use root test here
-Let us have the following sequence:
+## Try to use the root test here
+Consider the following sequence:
 
 $$
 r_k = \dfrac{1}{k^k}


### PR DESCRIPTION
For formal mathematical writing, "Consider" or "We define" are the best options. If you're aiming for a more conversational tone, "Let us consider" works well.

All the proposed changes are of so little importance, so I decided to group them into one commit.