### PR TITLE
Update Subgradient.md: Hölder inequality can be used only for p-norms

### DIFF
--- a/docs/theory/Subgradient.md
+++ b/docs/theory/Subgradient.md
@@ -10,7 +10,7 @@ $$
 f(x) \geq f(x_0) + \langle g, x - x_0 \rangle
 $$
 
-for some vector $g$, i.e., the tangent to the graph of the function is the *global* estimate from below for the function. 
+for some vector $g$, i.e., the tangent to the function's graph is the *global* estimate from below for the function. 
 
 ![Taylor linear approximation serves as a global lower bound for a convex function](conv_support.svg){#fig-conv_support}
 
@@ -257,7 +257,7 @@ B_{\lVert \cdot \rVert_*}(0, 1), & \text{if } x_0 = 0, \\
 \end{cases}
 $$
 
-Where $B_{\lVert \cdot \rVert_*}(0,1)$ is the closed unit ball centered at zero with respect to the conjugate norm. In other words, a vector $s \in V$ with $\lVert s \rVert_* = 1$ is a subgradient of the norm $\lVert \cdot \rVert$ at point $x_0 \neq 0$ if and only if the Hölder's inequality $\langle s, x_0 \rangle \leq \lVert x_0 \rVert$ becomes an equality.
+Where $B_{\lVert \cdot \rVert_*}(0,1)$ is the closed unit ball centered at zero with respect to the conjugate norm. In other words, a vector $s \in V$ with $\lVert s \rVert_* = 1$ is a subgradient of the norm $\lVert \cdot \rVert$ at point $x_0 \neq 0$ if and only if the inequality from the definition of the dual norm $\langle s, x_0 \rangle \leq \lVert x_0 \rVert$ becomes equality.
 
 ::: {.callout-proof collapse="true"} 
 Let $s \in V$. By definition, $s \in \partial \lVert \cdot \rVert (x_0)$ if and only if
@@ -291,7 +291,7 @@ $$
 
 Thus, equation is equivalent to $\lVert s \rVert_* \leq 1$ and $\langle s, x_0 \rangle = \lVert x_0 \rVert$.
 
-Consequently, it remains to note that for $x_0 \neq 0$, the inequality $\lVert s \rVert_* \leq 1$ must become an equality since, when $\lVert s \rVert_* < 1$, Hölder's inequality implies $\langle s, x_0 \rangle \leq \lVert s \rVert_* \lVert x_0 \rVert < \lVert x_0 \rVert$.
+Consequently, it remains to note that for $x_0 \neq 0$, the inequality $\lVert s \rVert_* \leq 1$ must become an equality since, when $\lVert s \rVert_* < 1$, definition of the dual norm implies $\langle s, x_0 \rangle \leq \lVert s \rVert_* \lVert x_0 \rVert < \lVert x_0 \rVert$.
 :::
 :::
 


### PR DESCRIPTION
Inequality used in the proof follows from one of the definitions of the dual norm. Hölder's inequality cannot be applied here, for not all norms in R^n are p-norms (see https://math.stackexchange.com/questions/2663321/examples-of-norms-essentially-different-from-p-norms).